### PR TITLE
Feat/#217 - 컨테이너 BaseImage 변경 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 
 jib{
     from{
-        image='adoptopenjdk/openjdk11:jre-11.0.2.9-alpine'
+        image='eclipse-temurin:17-jre-alpine'
     }
     to{
 //        image='asia-northeast3-docker.pkg.dev/dart-388516/cloud-run-source-deploy/dart-server:latest'


### PR DESCRIPTION

## ✨ 요약
- 자바 및 스프링 버전 마이그레이션에 따른 JIB에 활용되는 BaseImage 변경
- IssueNumber
  - #217

<br/>

## 😊 주요 변경점
- JIB BaseImage 변경
  - 기존: adoptopenjdk/openjdk11:jre-11.0.2.9-alpine
  - 변경: eclipse-temurin:17-jre-alpine

<br/>

## 📙 기타
- jvmFlags에 힙메모리 사이즈를 512mb보다 더 늘려도 되지 않을지 확인해보면 좋을 것 같아요 :)


<img width="738" alt="image" src="https://github.com/user-attachments/assets/3d44511c-1e72-4351-bb21-05b44d83819c">


<br/>
